### PR TITLE
perf: avoid test_inverse import-time compilation

### DIFF
--- a/src/InverseFunctions.jl
+++ b/src/InverseFunctions.jl
@@ -26,23 +26,14 @@ The function tests (as a `Test.@testset`) if
     On Julia >= 1.9, you have to load the `Test` standard library to be able to use
     this function.
 """
-function test_inverse end
+function test_inverse(args...; kwargs...)
+    length(args) == 2 || throw(MethodError(test_inverse, args))
+    throw(ArgumentError("InverseFunctions.test_inverse requires the Test standard library. Did you forget to load Test?"))
+end
 
 @static if !isdefined(Base, :get_extension)
     include("../ext/InverseFunctionsDatesExt.jl")
-    include("../ext/InverseFunctionsTestExt.jl") 
-end
-
-# Better error message if users forget to load Test
-if isdefined(Base, :get_extension) && isdefined(Base.Experimental, :register_error_hint)
-    function __init__()
-        Base.Experimental.register_error_hint(MethodError) do io, exc, _, _
-            if exc.f === test_inverse &&
-                (Base.get_extension(InverseFunctions, :InverseFunctionsTest) === nothing)
-                print(io, "\nDid you forget to load Test?")
-            end
-        end
-    end
+    include("../ext/InverseFunctionsTestExt.jl")
 end
 
 end # module

--- a/test/test_inverse.jl
+++ b/test/test_inverse.jl
@@ -43,6 +43,38 @@ end
     InverseFunctions.test_inverse(inverse, log, compare = ===)
 end
 
+@static if isdefined(Base, :get_extension)
+    @testset "test_inverse without Test" begin
+        script = """
+        using InverseFunctions
+        try
+            InverseFunctions.test_inverse(identity, 1)
+            exit(1)
+        catch err
+            showerror(stdout, err)
+            exit(err isa ArgumentError ? 0 : 1)
+        end
+        """
+        cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
+        output = read(ignorestatus(cmd), String)
+        @test occursin("Did you forget to load Test?", output)
+
+        script = """
+        using InverseFunctions
+        try
+            InverseFunctions.test_inverse(identity)
+            exit(1)
+        catch err
+            showerror(stdout, err)
+            exit(err isa MethodError ? 0 : 1)
+        end
+        """
+        cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
+        output = read(ignorestatus(cmd), String)
+        @test occursin("MethodError", output)
+    end
+end
+
 @testset "maths" begin
     InverseFunctions.test_inverse(!, false)
 


### PR DESCRIPTION
## Summary

Small load-time cleanup: replace the runtime `__init__` error hint with a direct `test_inverse` fallback method. Users still get a friendly error when `Test` is missing, but package import no longer pays for the error-hint hook.

## Benchmark

Measured with `julia --startup-file=no --project=@. -e 'using InteractiveUtils; @time_imports using InverseFunctions'` after precompile.
- before: `74.2 ms InverseFunctions`, `98.73% compilation time`
- after: `0.7 ms InverseFunctions`